### PR TITLE
AtomicBase GPS統合の実装 (Issue #2)

### DIFF
--- a/AtomicBaseGPS.cpp
+++ b/AtomicBaseGPS.cpp
@@ -1,0 +1,168 @@
+/*
+ * AtomicBaseGPS.cpp
+ * 
+ * Implementation for the AtomicBase GPS module
+ * 
+ * Created: 2025-03-23
+ * GitHub: https://github.com/kennel-org/polaris-navigator
+ */
+
+#include "AtomicBaseGPS.h"
+
+// Pin definitions for AtomicBase GPS
+#define GPS_TX_PIN 5   // GPS TX pin connected to this pin on AtomS3R
+#define GPS_RX_PIN -1  // Not used (one-way communication from GPS to AtomS3R)
+
+AtomicBaseGPS::AtomicBaseGPS() : 
+  _isValid(false),
+  _lastValidTime(0),
+  _latitude(0.0),
+  _longitude(0.0),
+  _altitude(0.0),
+  _satellites(0),
+  _hdop(99.99),
+  _speed(0.0),
+  _course(0.0),
+  _hour(0),
+  _minute(0),
+  _second(0),
+  _year(0),
+  _month(0),
+  _day(0) {
+}
+
+bool AtomicBaseGPS::begin(long baudRate) {
+  // Initialize GPS on Serial2 with specified baud rate
+  Serial2.begin(baudRate, SERIAL_8N1, GPS_TX_PIN, GPS_RX_PIN);
+  
+  // Wait a moment for GPS to initialize
+  delay(100);
+  
+  return true;
+}
+
+bool AtomicBaseGPS::update() {
+  // Read data from GPS
+  while (Serial2.available() > 0) {
+    char c = Serial2.read();
+    if (_gps.encode(c)) {
+      // New data was parsed
+      
+      // Update location data if valid
+      if (_gps.location.isValid()) {
+        _latitude = _gps.location.lat();
+        _longitude = _gps.location.lng();
+        _isValid = true;
+        _lastValidTime = millis();
+      }
+      
+      // Update altitude if valid
+      if (_gps.altitude.isValid()) {
+        _altitude = _gps.altitude.meters();
+      }
+      
+      // Update satellite data if valid
+      if (_gps.satellites.isValid()) {
+        _satellites = _gps.satellites.value();
+      }
+      
+      // Update HDOP if valid
+      if (_gps.hdop.isValid()) {
+        _hdop = _gps.hdop.hdop();
+      }
+      
+      // Update speed if valid
+      if (_gps.speed.isValid()) {
+        _speed = _gps.speed.kmph();
+      }
+      
+      // Update course if valid
+      if (_gps.course.isValid()) {
+        _course = _gps.course.deg();
+      }
+      
+      // Update time if valid
+      if (_gps.time.isValid()) {
+        _hour = _gps.time.hour();
+        _minute = _gps.time.minute();
+        _second = _gps.time.second();
+      }
+      
+      // Update date if valid
+      if (_gps.date.isValid()) {
+        _year = _gps.date.year();
+        _month = _gps.date.month();
+        _day = _gps.date.day();
+      }
+      
+      return true;
+    }
+  }
+  
+  // Check if we've lost GPS signal for more than 5 seconds
+  if (_isValid && (millis() - _lastValidTime > 5000)) {
+    _isValid = false;
+  }
+  
+  return false;
+}
+
+bool AtomicBaseGPS::isValid() const {
+  return _isValid;
+}
+
+float AtomicBaseGPS::getLatitude() const {
+  return _latitude;
+}
+
+float AtomicBaseGPS::getLongitude() const {
+  return _longitude;
+}
+
+float AtomicBaseGPS::getAltitude() const {
+  return _altitude;
+}
+
+uint8_t AtomicBaseGPS::getHour() const {
+  return _hour;
+}
+
+uint8_t AtomicBaseGPS::getMinute() const {
+  return _minute;
+}
+
+uint8_t AtomicBaseGPS::getSecond() const {
+  return _second;
+}
+
+uint16_t AtomicBaseGPS::getYear() const {
+  return _year;
+}
+
+uint8_t AtomicBaseGPS::getMonth() const {
+  return _month;
+}
+
+uint8_t AtomicBaseGPS::getDay() const {
+  return _day;
+}
+
+uint8_t AtomicBaseGPS::getSatellites() const {
+  return _satellites;
+}
+
+float AtomicBaseGPS::getHDOP() const {
+  return _hdop;
+}
+
+float AtomicBaseGPS::getSpeed() const {
+  return _speed;
+}
+
+float AtomicBaseGPS::getCourse() const {
+  return _course;
+}
+
+TinyGPSPlus* AtomicBaseGPS::getRawGPS() {
+  return &_gps;
+}

--- a/AtomicBaseGPS.h
+++ b/AtomicBaseGPS.h
@@ -1,0 +1,81 @@
+/*
+ * AtomicBaseGPS.h
+ * 
+ * Interface for the AtomicBase GPS module
+ * 
+ * Created: 2025-03-23
+ * GitHub: https://github.com/kennel-org/polaris-navigator
+ */
+
+#ifndef ATOMIC_BASE_GPS_H
+#define ATOMIC_BASE_GPS_H
+
+#include <Arduino.h>
+#include <TinyGPS++.h>
+
+class AtomicBaseGPS {
+public:
+  // Constructor
+  AtomicBaseGPS();
+  
+  // Initialize GPS module
+  bool begin(long baudRate = 9600);
+  
+  // Update GPS data (call this frequently)
+  bool update();
+  
+  // Check if GPS data is valid
+  bool isValid() const;
+  
+  // Get location data
+  float getLatitude() const;
+  float getLongitude() const;
+  float getAltitude() const;
+  
+  // Get time data
+  uint8_t getHour() const;
+  uint8_t getMinute() const;
+  uint8_t getSecond() const;
+  uint16_t getYear() const;
+  uint8_t getMonth() const;
+  uint8_t getDay() const;
+  
+  // Get satellite data
+  uint8_t getSatellites() const;
+  
+  // Get HDOP (Horizontal Dilution of Precision)
+  float getHDOP() const;
+  
+  // Get speed in km/h
+  float getSpeed() const;
+  
+  // Get course in degrees
+  float getCourse() const;
+  
+  // Get raw TinyGPS++ object for advanced usage
+  TinyGPSPlus* getRawGPS();
+  
+private:
+  TinyGPSPlus _gps;
+  bool _isValid;
+  unsigned long _lastValidTime;
+  
+  // GPS data
+  float _latitude;
+  float _longitude;
+  float _altitude;
+  uint8_t _satellites;
+  float _hdop;
+  float _speed;
+  float _course;
+  
+  // Time data
+  uint8_t _hour;
+  uint8_t _minute;
+  uint8_t _second;
+  uint16_t _year;
+  uint8_t _month;
+  uint8_t _day;
+};
+
+#endif // ATOMIC_BASE_GPS_H


### PR DESCRIPTION
AtomicBase GPSモジュールとのインターフェースを実装しました。\n\n主な変更点：\n- AtomicBaseGPSクラスの作成（AtomicBaseGPS.h/cpp）\n- GPS_TX_PIN = 5, GPS_RX_PIN = -1 の設定を使用\n- メインスケッチをAtomicBaseGPSクラスを使用するように更新\n- GPS状態表示機能の追加\n\nこの実装により、Issue #2「ハードウェアインターフェース - AtomicBase GPS統合」が解決されます。\n\nCloses #2