### PR TITLE
Fix IMU calibration and sensor initialization issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,30 @@ Polaris Navigator is a compact, portable device designed to assist astrophotogra
 - **Moon Phase Display**: Calculates and displays the current moon phase
 - **GPS Data Display**: Shows raw GPS data including latitude, longitude, and satellite status
 - **IMU Data Display**: Displays raw accelerometer, gyroscope, and magnetometer data for calibration
+- **IMU Calibration**: Provides a guided calibration process for the magnetometer and accelerometer/gyroscope sensors
 
 ## Hardware
 
 - AtomS3R (with built-in IMU)
+  - BMI270 (6-axis accelerometer/gyroscope)
+  - BMM150 (3-axis magnetometer)
 - AtomicBase GPS
 - Display device (built-in LCD or OLED)
+
+## IMU Calibration
+
+The AtomS3R features a 9-axis sensor system consisting of the BMI270 (6-axis accelerometer/gyroscope) and BMM150 (3-axis magnetometer). The calibration screen provides color-coded status indicators for sensor calibration and guides users through the calibration process:
+
+1. For magnetometer calibration: Rotate the device in a figure-8 pattern
+2. For accelerometer/gyroscope calibration: Flip the device in all directions
+
+Calibration status is displayed in three levels (GOOD, OK, POOR) and shows "NOT CALIBRATED" when sensors are uncalibrated.
+
+## Implementation Notes
+
+- The IMU functionality uses custom `IMUFusion`, `BMI270`, and `BMM150class` classes instead of the M5.Imu class
+- The IMUFusion class provides sensor fusion algorithms for accurate orientation data
+- GPS communication uses pins: TX = 5, RX = -1 (when using AtomicBase GPS)
 
 ## Development Status
 


### PR DESCRIPTION
## 変更内容
- M5.Imu.imuType()をM5.Imu.getType()に変更
- M5.Imu.setAccelRange()とM5.Imu.setGyroRange()をコメントアウト
- M5.Imu.setMagOpMode()をコメントアウト（bmm150.initialize()内で設定）
- M5.Imu.calibrateMag()をimuFusion.calibrateMagnetometer()に変更
- READMEにIMUキャリブレーションに関する情報を追加

## 修正理由
AtomS3RのIMUセンサー（BMI270とBMM150）を正しく初期化・キャリブレーションするため、M5.Imuクラスの代わりにIMUFusionクラスとBMM150classクラスを使用するように修正しました。これにより、IMUとGPSデータが正常に表示されるようになりました。